### PR TITLE
fixes Decimal value for DecimalColumn

### DIFF
--- a/ereports/engine/columns.py
+++ b/ereports/engine/columns.py
@@ -174,6 +174,10 @@ class StringFormatColumn(Column):
 class DecimalColumn(Column):
     wraps = Decimal
 
+    def get_value(self, obj, datasource):
+        value = self._get_value_from_attr(obj, self.attr, datasource)
+        return RowValue(self.wraps(value), self)
+
 
 class DateColumn(Column):
     wraps = datetime.date


### PR DESCRIPTION
In some cases the value showed by the report column is integer even if the column into the report is defined as DecimalColumn..
