### PR TITLE
fixes `RemovedInDjango18Warning`

### DIFF
--- a/ereports/forms.py
+++ b/ereports/forms.py
@@ -30,3 +30,4 @@ class ReportConfigurationForm(ModelForm):
 
     class Meta:
         model = ReportConfiguration
+        fields = '__all__'

--- a/ereports/forms.py
+++ b/ereports/forms.py
@@ -30,4 +30,19 @@ class ReportConfigurationForm(ModelForm):
 
     class Meta:
         model = ReportConfiguration
-        fields = '__all__'
+        fields = (
+            'name',
+            'group',
+            'template',
+            'description',
+            'report_class',
+            'target_model',
+            'published',
+            'select_related',
+            'use_distinct',
+            'columns',
+            'filtering',
+            'ordering',
+            'groupby',
+            'cache_key',
+        )


### PR DESCRIPTION
adds `fields = '__all__'` to `ReportConfigurationForm`
